### PR TITLE
ReSharper Out-of-Process support

### DIFF
--- a/src/dotnet/MediatorPlugin/ZoneMarker.cs
+++ b/src/dotnet/MediatorPlugin/ZoneMarker.cs
@@ -1,0 +1,8 @@
+﻿using JetBrains.Application.BuildScript.Application.Zones;
+using JetBrains.ReSharper.Resources.Shell;
+
+namespace ReSharper.MediatorPlugin
+{
+  [ZoneMarker(typeof(PsiFeaturesImplZone))]
+  public class ZoneMarker;
+}


### PR DESCRIPTION
Currently, the plugin is missing a zone marker. The lack of a zone marker activates it implicitly on both sides. Adding it should prevent actions from being registered in the Visual Studio process when out-of-process mode is enabled.