### PR TITLE
fix: update ProductVersion to 2025.3-EAP7-SNAPSHOT and improve identi…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ PublishToken="_PLACEHOLDER_"
 #   Release:  2020.2
 #   Nightly:  2020.3-SNAPSHOT
 #   EAP:      2020.3-EAP2-SNAPSHOT
-ProductVersion=2025.3-EAP2-SNAPSHOT
+ProductVersion=2025.3-EAP7-SNAPSHOT
 
 # Kotlin 1.4 will bundle the stdlib dependency by default, causing problems with the version bundled with the IDE
 # https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/#stdlib-default

--- a/src/dotnet/MediatorPlugin/ReSharper/Psi/Tree/IdentifierExtensions.cs
+++ b/src/dotnet/MediatorPlugin/ReSharper/Psi/Tree/IdentifierExtensions.cs
@@ -41,7 +41,9 @@ internal static class IdentifierExtensions
 
         IPsiServices psiServices = identifier.GetPsiServices();
         
-        if (identifier.Parent is not IDeclaration declaration)
+        string shortName = identifier.Name;
+        
+        if (string.IsNullOrEmpty(shortName))
             return EmptyTypeElements;
 
         if (requestTypeElements.Count == 0)
@@ -69,7 +71,7 @@ internal static class IdentifierExtensions
             (
                 psiServices
                     .Symbols
-                    .GetPossibleInheritors(declaration.DeclaredElement?.ShortName ?? "not found")
+                    .GetPossibleInheritors(shortName)
             )
             .ToList();
 

--- a/src/dotnet/Plugin.props
+++ b/src/dotnet/Plugin.props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-    <SdkVersion>2025.3.0-eap02</SdkVersion>
+    <SdkVersion>2025.3.0-eap07</SdkVersion>
     <Title>Mediator Extensions</Title>
     <Description>Ever got frustrated to find out where was the handler of a Mediator's IRequest or INotification? Say no more. This plugin provides a context action to easily reach the handler of any mediator request. Select your mediator request, click on that action and boom you will be automatically transported to the appropriate handler.</Description>
     <Authors>Octelys</Authors>


### PR DESCRIPTION
This pull request updates the plugin to use the latest EAP7 SDK and product versions, and refactors the logic for retrieving possible inheritors in `IdentifierExtensions.cs` to use a more robust approach based on the identifier's name. The main changes are grouped below:

Version updates:

* Updated `ProductVersion` in `gradle.properties` to `2025.3-EAP7-SNAPSHOT` to use the latest EAP version.
* Updated `SdkVersion` in `Plugin.props` to `2025.3.0-eap07` for compatibility with the latest SDK.

Code robustness improvements:

* In `IdentifierExtensions.cs`, changed the logic to use `identifier.Name` (short name) instead of relying on the parent declaration's `ShortName`, improving reliability when resolving possible inheritors. [[1]](diffhunk://#diff-ac8e32d090fd51f27282eeb60b38e407f3ba4cc7297daf8916826c86a9462353L44-R46) [[2]](diffhunk://#diff-ac8e32d090fd51f27282eeb60b38e407f3ba4cc7297daf8916826c86a9462353L72-R74)…fier handling in IdentifierExtensions